### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ OSM Shapefile QGIS stylesheets
 
 ![Example](https://raw.githubusercontent.com/charleyglynn/OSM-Shapefile-QGIS-stylesheets/master/Images/OSM_Jersey.png)
 
-##Background
+## Background
 
 I quite often use OSM data for personal mapping projects and I always use the ESRI Shapefiles from [Geofabrik](http://download.geofabrik.de/).
 There aren't many stylesheets available for use with this data so I decided to make my own. I found [this set](https://github.com/3liz/osm-in-qgis) from 3liz and used them as my starting point.
 
-##Info
+## Info
 
 These stylesheets have been designed to work at a large scale (1:4,000). They are legible between 1:2,000 and 1:5,000. I may adapt them to work at more scales in the future if need/time permits.
 
@@ -24,7 +24,7 @@ I recommend this layer order:
 
 ![layers](https://raw.githubusercontent.com/charleyglynn/OSM-Shapefile-QGIS-stylesheets/master/Images/Layer_Order.png)
 
-##Credit & Licence
+## Credit & Licence
 
 Thanks to the guys at [Geofabrik](http://download.geofabrik.de/) and [OpenStreetMapData](http://openstreetmapdata.com/data/land-polygons) for providing the ESRI Shapefiles.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
